### PR TITLE
Disable TLS certificate checking in "execAPI"

### DIFF
--- a/src/Network/API/Builder/API.hs
+++ b/src/Network/API/Builder/API.hs
@@ -72,7 +72,7 @@ execAPI :: MonadIO m
        -> APIT s e m a -- ^ the actual @API@ to run
        -> m (Either (APIError e) a) -- ^ IO action that returns either an error or the result
 execAPI b s api = do
-  m <- liftIO $ newManager conduitManagerSettings
+  m <- liftIO $ newManager $ mkManagerSettings (TLSSettingsSimple True False False) Nothing
   (res, _, _) <- runAPI b m s api
   liftIO $ closeManager m
   return res


### PR DESCRIPTION
Attempting to use your `reddit` package, I was running into "certificate has unknown CA" errors, which led me [here](https://github.com/snoyberg/http-client/issues/31). This implements the suggestion linked by @snoyberg in the first response.

Possibly not wise to make this change directly, as I'm sure many users are quite happy having their certificates checked, but it ought to be an option somewhere along the line -- e.g. via an `execAPI'`, maybe taking a ManagerSettings argument rather than simply asserting a default.