### PR TITLE
add support for GHCJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,6 @@ getAnswers = execAPI stackOverflow () $ runRoute answersRoute
 > getAnswers
 Right (Questions [Question {title = "Using parse API with codeigniter", isAnswered = True, score = 2, tags = ["php","codeigniter","parse.com","codeigniter-2","php-5.6"]},Question {title = "Object...
 ```
+
+If you have built code with GHCJS you can open `your-bin-dir/ghcjs-example.jsexe/index.html`
+in your browser and see the result of query execution in a browser console.

--- a/api-builder.cabal
+++ b/api-builder.cabal
@@ -31,23 +31,33 @@ library
     Network.API.Builder.Receive
     Network.API.Builder.Routes
     Network.API.Builder.Send
-    Network.API.Builder.Send.Multipart
+  if !impl(ghcjs)
+    exposed-modules:
+      Network.API.Builder.Send.Multipart
   build-depends:
     base >= 4.6 && < 4.9,
     aeson >= 0.9 && < 0.10,
     bifunctors >= 4.0 && < 6.0,
     bytestring == 0.10.*,
     HTTP == 4000.*,
-    http-client >= 0.4.11 && < 0.4.21,
-    http-client-tls >= 0.2 && < 0.2.3,
     http-types == 0.8.*,
     text == 1.*,
     transformers >= 0.4 && < 0.5
+  if !impl(ghcjs)
+      build-depends:
+        http-client >= 0.4.11 && < 0.4.21,
+        http-client-tls >= 0.2 && < 0.2.3
+  if impl(ghcjs)
+      build-depends:
+        ghcjs-base
+  js-sources: jsbits/xhr.js
+
   hs-source-dirs: src/
   default-language: Haskell2010
   default-extensions:
     FlexibleInstances
     OverloadedStrings
+    CPP
   ghc-options: -Wall
 
 test-suite test
@@ -88,3 +98,19 @@ test-suite test-io
     text,
     transformers
   GHC-options: -Wall
+
+
+executable ghcjs-example
+  if !impl(ghcjs)
+    Buildable: False
+  ghc-options: -Wall
+  cpp-options: -DGHCJS_BROWSER
+
+  default-extensions: CPP
+  default-language: Haskell2010
+  hs-source-dirs: ghcjs-example
+  main-is: Main.hs
+  build-depends: base
+               , api-builder
+  if impl(ghcjs)
+    build-depends: ghcjs-base

--- a/api-builder.cabal
+++ b/api-builder.cabal
@@ -36,7 +36,7 @@ library
       Network.API.Builder.Send.Multipart
   build-depends:
     base >= 4.6 && < 4.9,
-    aeson >= 0.9 && < 0.10,
+    aeson >= 0.9 && < 0.11,
     bifunctors >= 4.0 && < 6.0,
     bytestring == 0.10.*,
     HTTP == 4000.*,
@@ -45,8 +45,8 @@ library
     transformers >= 0.4 && < 0.5
   if !impl(ghcjs)
       build-depends:
-        http-client >= 0.4.11 && < 0.4.21,
-        http-client-tls >= 0.2 && < 0.2.3
+        http-client >= 0.4.11 && < 0.4.25,
+        http-client-tls >= 0.2 && < 0.3
   if impl(ghcjs)
       build-depends:
         ghcjs-base

--- a/api-builder.cabal
+++ b/api-builder.cabal
@@ -58,7 +58,6 @@ library
   default-extensions:
     FlexibleInstances
     OverloadedStrings
-    CPP
   ghc-options: -Wall
 
 test-suite test

--- a/api-builder.cabal
+++ b/api-builder.cabal
@@ -42,11 +42,11 @@ library
     HTTP == 4000.*,
     http-types >= 0.9,
     text == 1.*,
-    tls >= 1.2 && < 1.3.2,
+    tls >= 1.2 && < 1.3.5,
     transformers >= 0.4 && < 0.5
   if !impl(ghcjs)
       build-depends:
-        http-client >= 0.4.11 && < 0.4.25,
+        http-client >= 0.4.11 && < 0.4.28,
         http-client-tls >= 0.2 && < 0.3
   if impl(ghcjs)
       build-depends:

--- a/ghcjs-example/Main.hs
+++ b/ghcjs-example/Main.hs
@@ -1,0 +1,10 @@
+-- |
+
+module Main where
+
+import           Network.API.Builder.Examples.StackOverflow
+
+main :: IO ()
+main = do
+  res <- getAnswers
+  print res

--- a/jsbits/xhr.js
+++ b/jsbits/xhr.js
@@ -1,0 +1,16 @@
+function h$sendXHR(xhr, d, cont) {
+    xhr.addEventListener('error', function () {
+	cont(2);
+    });
+    xhr.addEventListener('abort', function() {
+	cont(1);
+    });
+    xhr.addEventListener('load', function() {
+	cont(0);
+    });
+    if(d) {
+	xhr.send(d);
+    } else {
+	xhr.send();
+    }
+}

--- a/src/Network/API/Builder/API.hs
+++ b/src/Network/API/Builder/API.hs
@@ -19,7 +19,16 @@ module Network.API.Builder.API (
   , name
   , baseURL
   , customizeRoute
-  , customizeRequest ) where
+  , customizeRequest
+#ifdef __GHCJS__
+  , Manager(..)
+  , ManagerSettings(..)
+  , httpLbs
+  , newManager
+  , closeManager
+  , tlsManagerSettings
+#endif
+  ) where
 
 import           Network.API.Builder.Builder
 import           Network.API.Builder.Error

--- a/src/Network/API/Builder/API.hs
+++ b/src/Network/API/Builder/API.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Network.API.Builder.API (
   -- * API
     API

--- a/src/Network/API/Builder/API.hs
+++ b/src/Network/API/Builder/API.hs
@@ -21,23 +21,54 @@ module Network.API.Builder.API (
   , customizeRoute
   , customizeRequest ) where
 
-import Network.API.Builder.Builder
-import Network.API.Builder.Error
-import Network.API.Builder.Receive
-import Network.API.Builder.Routes
-import Network.API.Builder.Send
+import           Network.API.Builder.Builder
+import           Network.API.Builder.Error
+import           Network.API.Builder.Receive
+import           Network.API.Builder.Routes
+import           Network.API.Builder.Send
 
-import Data.Bifunctor
-import Control.Exception
-import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Except
-import Control.Monad.Trans.Reader
-import Control.Monad.Trans.State
-import Data.ByteString.Lazy (ByteString)
-import Data.Text (Text)
+import           Control.Exception
+import           Control.Monad.IO.Class      (MonadIO, liftIO)
+import           Control.Monad.Trans.Class   (lift)
+import           Control.Monad.Trans.Except
+import           Control.Monad.Trans.Reader
+import           Control.Monad.Trans.State
+import           Data.Bifunctor
+import           Data.Text                   (Text)
+
+#ifdef __GHCJS__
+
+import JavaScript.Web.XMLHttpRequest
+import           Data.ByteString        (ByteString)
+
+#else
+
+import           Data.ByteString.Lazy        (ByteString)
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
+
+#endif
+
+#ifdef __GHCJS__
+data Manager = Manager
+
+data ManagerSettings = ManagerSettings
+
+httpLbs :: Request -> Manager -> IO (Response ByteString)
+
+httpLbs req _ =
+  xhrByteString req
+
+newManager :: ManagerSettings -> IO Manager
+newManager _ = return Manager
+
+closeManager :: Manager -> IO ()
+closeManager _ = return ()
+
+tlsManagerSettings :: ManagerSettings
+tlsManagerSettings = ManagerSettings
+
+#endif
 
 -- | Main API type. @s@ is the API's internal state, @e@ is the API's custom error type,
 --   and @a@ is the result when the API runs. Based on the @APIT@ transformer.

--- a/src/Network/API/Builder/Builder.hs
+++ b/src/Network/API/Builder/Builder.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Network.API.Builder.Builder
   ( Builder(..)
   , basicBuilder ) where

--- a/src/Network/API/Builder/Builder.hs
+++ b/src/Network/API/Builder/Builder.hs
@@ -5,7 +5,11 @@ module Network.API.Builder.Builder
 import Network.API.Builder.Routes
 
 import Data.Text (Text)
+#ifdef __GHCJS__
+import JavaScript.Web.XMLHttpRequest (Request)
+#else
 import Network.HTTP.Client (Request)
+#endif
 import qualified Data.Text as T
 
 -- | Builder type for the API. Keeps track of the API's name and base URL, and how

--- a/src/Network/API/Builder/Error.hs
+++ b/src/Network/API/Builder/Error.hs
@@ -2,8 +2,16 @@ module Network.API.Builder.Error
   ( APIError(..) ) where
 
 import Data.Monoid
+#ifdef __GHCJS__
+import JavaScript.Web.XMLHttpRequest (XHRError)
+#else
 import Network.HTTP.Client (HttpException)
+#endif
 import Prelude
+
+#ifdef __GHCJS__
+type HttpException = XHRError
+#endif
 
 -- | Error type for the @API@, where @a@ is the type that should be returned when
 --   something goes wrong on the other end - i.e. any error that isn't directly related

--- a/src/Network/API/Builder/Error.hs
+++ b/src/Network/API/Builder/Error.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Network.API.Builder.Error
   ( APIError(..) ) where
 

--- a/src/Network/API/Builder/Receive.hs
+++ b/src/Network/API/Builder/Receive.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Network.API.Builder.Receive where
 

--- a/src/Network/API/Builder/Routes.hs
+++ b/src/Network/API/Builder/Routes.hs
@@ -49,7 +49,7 @@ routeURL baseURL (Route fs ps _) =
   where
     firstSep = if null fs then T.empty else "/"
     path = T.intercalate "/" fs
-    querySep = if null ps then T.empty else "" fs
+    querySep = if null ps then T.empty else "?"
 
 buildParams :: [URLParam] -> Text
 buildParams = T.pack . HTTP.urlEncodeVars . concatMap (map (T.unpack *** T.unpack))

--- a/src/Network/API/Builder/Routes.hs
+++ b/src/Network/API/Builder/Routes.hs
@@ -49,12 +49,7 @@ routeURL baseURL (Route fs ps _) =
   where
     firstSep = if null fs then T.empty else "/"
     path = T.intercalate "/" fs
-    querySep = if null ps then T.empty else pathParamsSep fs
-
-
-pathParamsSep :: [URLPiece] -> Text
-pathParamsSep [] = "?"
-pathParamsSep xs = if T.isInfixOf "." (last xs) then "?" else "/?"
+    querySep = if null ps then T.empty else "" fs
 
 buildParams :: [URLParam] -> Text
 buildParams = T.pack . HTTP.urlEncodeVars . concatMap (map (T.unpack *** T.unpack))

--- a/src/Network/API/Builder/Send.hs
+++ b/src/Network/API/Builder/Send.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Network.API.Builder.Send where
 
 import Network.API.Builder.Builder

--- a/src/Network/API/Builder/Send.hs
+++ b/src/Network/API/Builder/Send.hs
@@ -4,15 +4,112 @@ import Network.API.Builder.Builder
 import Network.API.Builder.Routes
 
 import Data.Aeson
+
+#ifdef __GHCJS__
+
+import JavaScript.Web.XMLHttpRequest
+import           Data.JSString.Text
+import qualified Data.Text.Encoding as TE
+import qualified Data.Text.Lazy.Encoding as LTE
+import Control.Arrow ((***))
+import Data.String (IsString)
+import Data.ByteString (ByteString)
+
+#else
+
 import Data.ByteString.Lazy (ByteString)
 import Network.HTTP.Client
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.Text as Text
 
+#endif
+
+
 -- | Class for types that can be sent with api-builder.
 --   Given a 'Builder', a 'Route', and an instance of 'Sendable', we should be able to construct a 'Request' for the API's server. If we can't, 'send' returns 'Nothing' and 'APIT' complains about being unable to send the given data.
 class Sendable s where
   send :: Builder -> Route -> s -> Maybe Request
+
+-- | By default, the '()' instance for 'Sendable' moves the query parameters of the 'Route' into the body of the POST request. Most APIs handle both, but some will complain if they aren't sent in the actual query. If you 'send' 'PostQuery' instead of '()', the query params won't move from the actual query string when constructing the request.
+data PostQuery = PostQuery
+  deriving (Show)
+
+#ifdef __GHCJS__
+
+instance Sendable () where
+  send builder r () =
+    let method = nameToMethod $ httpMethod r
+        route = _customizeRoute builder r
+        uri = routeURL (_baseURL builder) route
+        req = Request{reqMethod = method
+                     , reqWithCredentials = True
+                     , reqURI = textToJSString uri
+                     , reqLogin = Nothing
+                     , reqHeaders = []
+                     , reqData = if method == POST
+                                 then paramsToForm $ urlParams route
+                                 else NoData
+                     }
+
+    in
+      Just $ _customizeRequest builder req
+    where
+      paramsToForm =
+        FormData . concatMap (map (textToJSString *** (StringVal . textToJSString)))
+
+instance Sendable Value where
+  send builder r value =
+    case nameToMethod $ httpMethod r of
+      method@(POST) -> do
+        let route = _customizeRoute builder r
+            uri = routeURL (_baseURL builder) route
+            req = Request{reqMethod = method
+                         , reqWithCredentials = True
+                         , reqURI = textToJSString uri
+                         , reqLogin = Nothing
+                         , reqHeaders = [("Content-Type", "application/json")]
+                         , reqData = StringData . lazyTextToJSString . LTE.decodeUtf8 $
+                                     encode value
+                         }
+
+          in
+          Just $ _customizeRequest builder req
+      _ ->
+        Nothing
+
+instance Sendable ByteString where
+  send builder r bs =
+    case httpMethod r of
+      "POST" -> do
+        req <- basicSend builder r
+        return $ req {reqData = StringData . textToJSString . TE.decodeUtf8 $ bs}
+      _ -> Nothing
+
+instance Sendable PostQuery where
+  send builder r PostQuery = basicSend builder r
+
+basicSend :: Builder -> Route -> Maybe Request
+basicSend builder r =
+  let method = nameToMethod $ httpMethod r
+      route = _customizeRoute builder r
+      uri = routeURL (_baseURL builder) route
+  in
+    Just $ Request{reqMethod = method
+                  , reqWithCredentials = True
+                  , reqURI = textToJSString uri
+                  , reqLogin = Nothing
+                  , reqHeaders = []
+                  , reqData = NoData
+                  }
+
+nameToMethod :: (Eq a, Show a, IsString a) => a -> Method
+nameToMethod "POST" = POST
+nameToMethod "GET" = GET
+nameToMethod "PUT" = PUT
+nameToMethod "DELETE" = DELETE
+nameToMethod m = error $ "unsupported http method " ++ show m
+
+#else
 
 instance Sendable () where
   send builder r () =
@@ -51,9 +148,7 @@ instance Sendable ByteString where
         return $ req { requestBody = RequestBodyLBS bs }
       _ -> Nothing
 
--- | By default, the '()' instance for 'Sendable' moves the query parameters of the 'Route' into the body of the POST request. Most APIs handle both, but some will complain if they aren't sent in the actual query. If you 'send' 'PostQuery' instead of '()', the query params won't move from the actual query string when constructing the request.
-data PostQuery = PostQuery
-  deriving (Show)
-
 instance Sendable PostQuery where
   send builder r PostQuery = basicSend builder r
+
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,32 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.6
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 0.1.4.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
Added support for GHCJS and appropriate example.

The main diffrerence with GHC version is usage of strict ByteStrings instead of lazy ones.
Also no support for multipart bodies yet.

Code was compiled under GHCJS 7.10.2 with latest improved-base branch.

At least StackOverflow example works well without problems.
