### PR TITLE
Bump aeson upper bound

### DIFF
--- a/api-builder.cabal
+++ b/api-builder.cabal
@@ -34,7 +34,7 @@ library
     Network.API.Builder.Send.Multipart
   build-depends:
     base >= 4.6 && < 4.10,
-    aeson >= 0.9 && < 0.12,
+    aeson >= 0.9 && < 1.1,
     bifunctors >= 4.0 && < 6.0,
     bytestring == 0.10.*,
     HTTP == 4000.*,


### PR DESCRIPTION
Test run fine after this change with the latest version of aeson.
